### PR TITLE
Add  processing for asynchronous request

### DIFF
--- a/nginx/main.lua
+++ b/nginx/main.lua
@@ -14,6 +14,16 @@ if res then
     return
 end
 
+local is_xhr = false
+if ngx.req.get_headers()["X-Requested-With"] == "XMLHttpRequest" then
+    is_xhr = true 
+end
+
+if is_xhr then
+    ngx.exit(ngx.HTTP_UNAUTHORIZED)
+    return
+end
+
 local opts = {
     ssl_verify = "no",
     redirect_uri = "http://localhost/cb",
@@ -36,7 +46,7 @@ if not ok then
     return
 end
 ngx.header['Set-Cookie'] = "sid=" .. session_val .. "; path=/"
-if ngx.req.get_headers()["X-Requested-With"] then
+if is_xhr then
     ngx.exit(ngx.HTTP_OK)
     return
 end


### PR DESCRIPTION
Asynchronous requests cannot handle status 30X.
So, when the X-Requested-With header is XMLHttpRequest, status code 401 is returned as a response.