### PR TITLE
Use lua-resty-session

### DIFF
--- a/nginx/main.lua
+++ b/nginx/main.lua
@@ -1,29 +1,3 @@
-local redis = require "resty.redis"
-local red = redis:new()
-
-local ok, err = red:connect("redis", 6379)
-if not ok then
-    ngx.say("connection error: ", err)
-    return
-end
-
-local cookie = ngx.var.cookie_sid
-local res, err = red:get(cookie)
-if res then
-    ngx.var.pass = "http://webapp:3000/"
-    return
-end
-
-local is_xhr = false
-if ngx.req.get_headers()["X-Requested-With"] == "XMLHttpRequest" then
-    is_xhr = true 
-end
-
-if is_xhr then
-    ngx.exit(ngx.HTTP_UNAUTHORIZED)
-    return
-end
-
 local opts = {
     ssl_verify = "no",
     redirect_uri = "http://localhost/cb",
@@ -39,15 +13,4 @@ if err then
 end
 ngx.req.set_header("X-USER", res.id_token.sub)
 
-local session_val = "dummy"
-ok, err = red:setex(session_val, 100, res.id_token.sub)
-if not ok then
-    ngx.say("failed to set: ", err)
-    return
-end
-ngx.header['Set-Cookie'] = "sid=" .. session_val .. "; path=/"
-if is_xhr then
-    ngx.exit(ngx.HTTP_OK)
-    return
-end
-ngx.redirect(ngx.var.request_uri)
+ngx.var.pass="http://webapp:3000/"

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -55,6 +55,10 @@ http {
 
         location / {
                 set $pass '';
+                set $session_storage redis;
+                set $session_redis_prefix        sessions;
+                set $session_redis_host          redis;
+                set $session_redis_port          6379;
                 default_type 'text/html';
                 access_by_lua_file /usr/local/openresty/main.lua;
                 proxy_pass $pass;


### PR DESCRIPTION
I noticed that lua-resty-openidc uses lua-resty-session internally.
So I changed to use Redis through lua-resty-session.
https://github.com/zmartzone/lua-resty-openidc#lua-resty-openidc